### PR TITLE
Remove XML declare tag to prevent unexpected error

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -47,3 +47,11 @@ test('collect duplicate tags in array', () => {
 
   expect(json.entry.content.IntervalBlock.IntervalReadings).toBeInstanceOf(Array);
 });
+
+test('remove xml declare tag', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://naesb.org/espi espi.xsd"><id>urn:uuid:0f30576c-a6c0-4aae-9889-91e3466d18ff</id><title>SDG&E Generated AMI Data File for Enertalk</title><author><name>Meter Data Service (MDS)</name></author></feed>`;
+  const json = espiParser(xml);
+  console.log(json);
+  expect(typeof json.feed === 'object').toBeTruthy();
+});

--- a/index.js
+++ b/index.js
@@ -30,14 +30,22 @@ function normalizeChildren(arr = []) {
 }
 
 function preprocess(xml = '') {
+  const xmlDeclareTagRegex = /^(<\?xml|<\? xml)(.*)>/;
   const cdataRegex = /<!\[CDATA\[|\]\]>/g;
-  return xml.replace(cdataRegex, '');
+  return xml
+    .replace(xmlDeclareTagRegex, '')
+    .replace(cdataRegex, '');
 }
 
 function mapXMLToJSON(xml) {
   const trimmedXml = preprocess(xml);
 
   const xmlObj = xmlParser(trimmedXml);
+
+  if (!xmlObj.root) {
+    return null;
+  }
+
   return {
     [removeNamespace(xmlObj.root.name)]: normalizeChildren(xmlObj.root.children),
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "espi-parser",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/yongdamsh/espi-parser.git",


### PR DESCRIPTION
If target XML contains incompleted declare tag(e.g. <?xml ...>), parsing job will be failed with unxpected error.
So just remove the tag before processing.